### PR TITLE
set web container NODE_ENV var to development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       context: ./
       dockerfile: Dockerfile.dev
     environment:
+      NODE_ENV: development
       MSSQLSERVER_URL: mssql://sa:Password!!11@mssqlserver:1433/Dev
       LOCONOMICS_BACKEND_URL: https://dev.loconomics.com
       PATH: /usr/local/bin:/usr/bin:/bin:/host/node_modules/.bin


### PR DESCRIPTION
Setting `web` container `NODE_ENV=development` so that yarn installs `devDependencies` during `docker-compose up`.