### PR TITLE
Minor Eslint fixes

### DIFF
--- a/api/responses/notFound.js
+++ b/api/responses/notFound.js
@@ -29,7 +29,7 @@
 module.exports = function notFound(optionalData) {
 
   // Get access to `req` and `res`
-  var req = this.req;
+  //var req = this.req;
   var res = this.res;
 
   // Define the status code to send in the response.

--- a/api/responses/unauthorized.js
+++ b/api/responses/unauthorized.js
@@ -29,7 +29,7 @@
 module.exports = function unauthorized(optionalData) {
 
   // Get access to `req` and `res`
-  var req = this.req;
+  //var req = this.req;
   var res = this.res;
 
   // Define the status code to send in the response.

--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@
  *   https://sailsjs.com/anatomy/app.js
  */
 
-require("reflect-metadata")
+require('reflect-metadata');
 require('ts-node/register');
 
 // Ensure we're in the project directory, so cwd-relative paths work as expected

--- a/config/http.js
+++ b/config/http.js
@@ -9,14 +9,14 @@
  * https://sailsjs.com/config/http
  */
 
-const MetricsMiddleware = require('http-metrics-middleware')
+const MetricsMiddleware = require('http-metrics-middleware');
 
-const {auth, initialize} = require('../api/middleware/auth')
-const i18n = require('../api/middleware/i18n')
-const backend = require('../api/middleware/proxy').backend
-const pages = require('../api/middleware/proxy').pages
+const {auth, initialize} = require('../api/middleware/auth');
+const i18n = require('../api/middleware/i18n');
+const backend = require('../api/middleware/proxy').backend;
+const pages = require('../api/middleware/proxy').pages;
 
-const metrics = (new MetricsMiddleware()).initRoutes()
+const metrics = (new MetricsMiddleware()).initRoutes();
 
 module.exports.http = {
 


### PR DESCRIPTION
## ESLint reported errors fixed
```
ectos\Loconomics\loconomics-backend\api\responses\notFound.js
  32:7  warning  'req' is assigned a value but never used. Allowed unused vars must match /^unused($|[A-Z].*$)/  no-unused-vars

D:\Iago\Proxectos\Loconomics\loconomics-backend\api\responses\unauthorized.js
  32:7  warning  'req' is assigned a value but never used. Allowed unused vars must match /^unused($|[A-Z].*$)/  no-unused-vars

D:\Iago\Proxectos\Loconomics\loconomics-backend\app.js
  23:9   warning  Strings must use singlequote  quotes
  23:28  error    Missing semicolon             semi

D:\Iago\Proxectos\Loconomics\loconomics-backend\config\http.js
  12:61  error  Missing semicolon  semi
  14:61  error  Missing semicolon  semi
  15:47  error  Missing semicolon  semi
  16:59  error  Missing semicolon  semi
  17:55  error  Missing semicolon  semi
  19:55  error  Missing semicolon  semi

✖ 10 problems (7 errors, 3 warnings)
  7 errors, 1 warning potentially fixable with the `--fix` option.
```